### PR TITLE
Fix missing XML documentation in NuGet package

### DIFF
--- a/src/SharpWebview/SharpWebview.csproj
+++ b/src/SharpWebview/SharpWebview.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>SharpWebview</AssemblyName>
     <Authors>Gerrit 'Geaz' Gazic</Authors>
     <Owners>Gerrit 'Geaz' Gazic</Owners>


### PR DESCRIPTION
It looks like the XML documentation is by default not generated for SDK-style class library projects. According to [the documentation](https://docs.microsoft.com/dotnet/csharp/codedoc) setting the `GenerateDocumentationFile` MSBuild property to `true` should resolve this issue. The package step should then automatically pick up and include the resulting XML file in the NuGet package due to the defaults used for that - none of which have been changed in this project.