### PR TITLE
Add binding for Terminate method

### DIFF
--- a/src/SharpWebview/Webview.cs
+++ b/src/SharpWebview/Webview.cs
@@ -188,6 +188,14 @@ namespace SharpWebview
         }
 
         /// <summary>
+        /// Terminates the webview.
+        /// </summary>
+        public void Terminate()
+        {
+            Bindings.webview_terminate(_nativeWebview);
+        }
+
+        /// <summary>
         /// Disposes the current webview.
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
Adds a binding for the webview terminate method. Calling this method allows you to close the Webview and continue execution from where the `Run()` method was called from.

My use case for this is to close the Webview once the required user interaction has finished. Additionally with this method, I can implement a binding which can be called from the JavaScript to close the Webview programmatically, which is not usually possible from the JS executing in the Webview.